### PR TITLE
Add phylo hashmap to denote parent-child relationships

### DIFF
--- a/Chromo.java
+++ b/Chromo.java
@@ -14,6 +14,8 @@ public class Chromo
 *******************************************************************************/
 
 	public static int[][] genome;
+    public static int id;
+    public static int pid1, pid2;
 	
 	static {
     	    String filename = "AdaptiCritters_Template_numGenes_" + SimulationGenerator.numGenes

--- a/Chromo.java
+++ b/Chromo.java
@@ -15,7 +15,6 @@ public class Chromo
 
 	public static int[][] genome;
     public static int id;
-    public static int pid1, pid2;
 	
 	static {
     	    String filename = "AdaptiCritters_Template_numGenes_" + SimulationGenerator.numGenes

--- a/Search.java
+++ b/Search.java
@@ -109,6 +109,7 @@ public class Search {
 		bestOfGenChromo = new Chromo();
 		bestOfRunChromo = new Chromo();
 		bestOverAllChromo = new Chromo();
+        HashMap<Integer, Integer> phylo = new HashMap<Integer, Integer>();
 
 		if (Parameters.minORmax.equals("max")){
 			defaultBest = 0;
@@ -328,6 +329,8 @@ public class Search {
 					randnum = r.nextDouble();
 					if (randnum < Parameters.xoverRate){
 						Chromo.mateParents(parent1, parent2, member[parent1], member[parent2], child[i], child[i+1]);
+                        phylo.put(child[i].id, new int[]{member[parent1].id, member[parent2].id});
+                        phylo.put(child[i+1].id, new int[]{member[parent1].id, member[parent2].id});
 					}
 					else {
 						Chromo.mateParents(parent1, member[parent1], child[i]);


### PR DESCRIPTION
At the moment, the `phylo` HashMap in `Search.java` holds the child ID as the key and an integer array with its two parent IDs as the value.