### PR TITLE
Track parent-child relationships and add start/end generation attribute

### DIFF
--- a/Chromo.java
+++ b/Chromo.java
@@ -24,6 +24,9 @@ public class Chromo
 	public double sclFitness;
 	public double proFitness;
 	public int id; // Tracks individual by ID# for phylogeny
+    public List<Chromo> parents;
+    public int startGen;
+    public int endGen;
 
 /*******************************************************************************
 *                            INSTANCE VARIABLES                                *
@@ -43,6 +46,7 @@ public class Chromo
 				this.chromo[i] = allele;
 		}
 
+        this.parents = new ArrayList<Chromo>();
 		this.id = cumPop++; // ID = current cumPop then increments cumPop by 1
 		this.rawFitness = -1;   //  Fitness not yet evaluated
 		this.sclFitness = -1;   //  Fitness not yet scaled
@@ -152,6 +156,13 @@ public class Chromo
 	// 		//  Create child chromosome from parental material
 	// 		child1.chromo = parent1.chromo.substring(0,xoverPoint1) + parent2.chromo.substring(xoverPoint1);
 	// 		child2.chromo = parent2.chromo.substring(0,xoverPoint1) + parent1.chromo.substring(xoverPoint1);
+            
+            // // Associate parents to children (move/modify this block as you see fit when crossover is implemented);
+            // child1.parents.add(parent1);
+            // child1.parents.add(parent2);
+            // child2.parents.add(parent1);
+            // child2.parents.add(parent2);
+
 	// 		break;
 
 	// 	case 2:     //  Two Point Crossover

--- a/Search.java
+++ b/Search.java
@@ -127,10 +127,13 @@ public class Search {
 			bestOfRunChromo.rawFitness = defaultBest;
 			System.out.println();
 
+            // Holds history of all individuals and their parent-child relationships
+            List<Chromo> phylo = new ArrayList<Chromo>();
+
 			//	Initialize First Generation
 			for (int i=0; i<Parameters.popSize; i++){
-				member[i] = new Chromo();
-				child[i] = new Chromo();
+				phylo.add(member[i] = new Chromo());
+				// phylo.add(child[i] = new Chromo());
 			}
 
 			//	Begin Each Run
@@ -328,6 +331,10 @@ public class Search {
 					randnum = r.nextDouble();
 					if (randnum < Parameters.xoverRate){
 						// Chromo.mateParents(parent1, parent2, member[parent1], member[parent2], child[i], child[i+1]);
+                        
+                        // Add children to phylo (move/modify this block as you see fit when crossover is implemented)
+                        phylo.add(child[i]);
+                        phylo.add(child[i+2]);
 					}
 					else {
 						Chromo.mateParents(parent1, member[parent1], child[i]);


### PR DESCRIPTION
Added basic logic to tracking all individuals throughout all generations per run. `startGen` and `endGen` have not been initialized in the constructor yet and are included in preparation for future stat tracking.